### PR TITLE
Beginning of a cleaner rewrite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-syn = { version = "2", features = ["full", "visit"] }
+syn = { version = "2", features = ["full", "visit", "extra-traits"] }
 petgraph = "0.6"
 plotters = "0.3"
 plotters-svg = "0.3"
 walkdir = "2.3"
-clap = "4.5"
+clap = { version = "4.5", features = ["derive"] }
+proc-macro2 = "1.0"

--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -1,0 +1,5 @@
+use super::Ident;
+
+pub struct Function {
+    pub(crate) name: Ident,
+}

--- a/src/ast/ident.rs
+++ b/src/ast/ident.rs
@@ -1,0 +1,9 @@
+use proc_macro2::Span;
+
+pub struct Ident(String, Span);
+
+impl From<&syn::Ident> for Ident {
+    fn from(value: &syn::Ident) -> Self {
+        Self(value.to_string(), value.span())
+    }
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,0 +1,5 @@
+pub use function::Function;
+pub use ident::Ident;
+
+mod function;
+mod ident;

--- a/src/cli/graph.rs
+++ b/src/cli/graph.rs
@@ -1,0 +1,13 @@
+use clap::Args;
+
+use std::path::PathBuf;
+
+#[derive(Debug, Args)]
+pub struct GraphCommand {
+    /// Directory to audit
+    pub directory: PathBuf,
+    
+    /// Path to the resulting output file (by default it will place in the path target/e2-graph) 
+    #[arg(short)]
+    pub output: Option<PathBuf>
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,17 @@
+use clap::{Parser, Subcommand};
+use graph::GraphCommand;
+
+mod graph;
+
+#[derive(Debug, Parser)]
+#[command(name = "e2")]
+#[command(about = "Rust-based tool for visualizing and auditing the call graph of a Rust-based smart contract project.", long_about = None)]
+pub struct App {
+    #[command(subcommand)]
+    pub command: SubCommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SubCommands {
+    Graph(GraphCommand),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod ast;
+pub mod cli;
+pub mod visitors;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,143 +1,34 @@
-use syn::{ visit::Visit, File, ItemFn };
-use std::fs;
-use std::collections::HashMap;
-use std::path::Path;
+use std::process::exit;
+
+use clap::Parser;
+use e2::cli::{App, SubCommands};
+use syn::visit::Visit;
 use walkdir::WalkDir;
-use petgraph::graph::DiGraph;
-use plotters::prelude::*;
-use plotters::style::WHITE;
-
-// Visitor to collect function names and relationships
-struct FunctionVisitor {
-    // TODO: use a Function structure instead of a string
-    functions: Vec<String>,
-    calls: HashMap<String, Vec<String>>,
-}
-
-impl FunctionVisitor {
-    pub fn new() -> Self {
-        Self {
-            functions: Vec::new(),
-            calls: HashMap::new()
-        }
-    }
-}
-
-impl<'ast> Visit<'ast> for FunctionVisitor {
-    fn visit_item_fn(&mut self, node: &'ast ItemFn) {
-        let fn_name = node.sig.ident.to_string();
-        let mut called_functions = Vec::new();
-
-        for stmt in &node.block.stmts {
-            if let syn::Stmt::Expr(expr, _) = stmt {
-                if let syn::Expr::Call(call_expr) = expr {
-                    if let syn::Expr::Path(path) = *call_expr.func.clone() {
-                        if let Some(segment) = path.path.segments.first() {
-                            called_functions.push(segment.ident.to_string());
-                        }
-                    }
-                }
-            }
-        }
-
-        self.calls.insert(fn_name.clone(), called_functions);
-        self.functions.push(fn_name);
-
-        syn::visit::visit_item_fn(self, node);
-    }
-}
-
-// Recursively parse all Rust files in the directory
-fn parse_rust_code_recursive<P: AsRef<Path>>(dir: P) -> HashMap<String, Vec<String>> {
-    let mut calls = HashMap::new();
-
-    for entry in WalkDir::new(dir)
-        .into_iter()
-        .filter_map(Result::ok)
-        .filter(
-            |e|
-                e
-                    .path()
-                    .extension()
-                    .and_then(|ext| ext.to_str()) == Some("rs")
-        ) {
-        let code = fs::read_to_string(entry.path()).expect("Could not read the file");
-        let syntax_tree: File = syn::parse_file(&code).expect("Failed to parse the file");
-
-        let mut visitor = FunctionVisitor::new();
-        visitor.visit_file(&syntax_tree);
-
-        for (key, value) in visitor.calls {
-            calls.entry(key).or_insert_with(Vec::new).extend(value);
-        }
-    }
-
-    calls
-}
-
-// Build the call graph using petgraph
-fn build_call_graph(function_calls: HashMap<String, Vec<String>>) -> DiGraph<String, ()> {
-    let mut graph = DiGraph::new();
-    let mut node_map = HashMap::new();
-
-    for function in function_calls.keys() {
-        let node = graph.add_node(function.clone());
-        node_map.insert(function, node);
-    }
-
-    for (function, calls) in &function_calls {
-        if let Some(&caller_node) = node_map.get(function) {
-            for callee in calls {
-                if let Some(&callee_node) = node_map.get(callee) {
-                    graph.add_edge(caller_node, callee_node, ());
-                }
-            }
-        }
-    }
-
-    graph
-}
-
-// Render the call graph to an SVG file using plotters
-fn render_graph_to_svg(graph: &DiGraph<String, ()>, file_name: &str) {
-    let root = SVGBackend::new(file_name, (800, 600)).into_drawing_area();
-    root.fill(&WHITE).unwrap();
-
-    let mut chart = ChartBuilder::on(&root)
-        .caption("Call Graph", ("sans-serif", 30).into_font())
-        .build_cartesian_2d(0..10, 0..10)
-        .unwrap();
-
-    for (index, node) in graph.node_indices().enumerate() {
-        let label = graph[node].clone();
-        chart
-            .draw_series(
-                PointSeries::of_element(
-                    vec![(index as i32, 10 - (index as i32))],
-                    5,
-                    &BLACK,
-                    &(|coord, size, style| {
-                        EmptyElement::at(coord) +
-                            Circle::new((0, 0), size, style.filled()) +
-                            Text::new(label.clone(), (10, 0), ("sans-serif", 15))
-                    })
-                )
-            )
-            .unwrap();
-    }
-
-    root.present().unwrap();
-}
 
 fn main() {
-    // Parse the Rust project in the current directory
-    let function_calls = parse_rust_code_recursive(".");
+    let app = App::parse();
+    match app.command {
+        SubCommands::Graph(graph) => {
+            if !graph.directory.exists() {
+                eprintln!(
+                    "error: The directory '{}' does not exist, please give a correct directory.",
+                    graph.directory.display()
+                );
+                exit(1)
+            }
 
-    // Build the call graph
-    let graph = build_call_graph(function_calls);
+            for entry in WalkDir::new(graph.directory)
+                .into_iter()
+                .filter_map(Result::ok)
+                .filter(|e| e.path().extension().and_then(|ext| ext.to_str()) == Some("rs"))
+            {
+                let code = std::fs::read_to_string(entry.path()).expect("Could not read the file");
+                let syntax_tree: syn::File =
+                    syn::parse_file(&code).expect("Failed to parse the file");
 
-    // Render the graph as an SVG image
-    render_graph_to_svg(&graph, "call_graph.svg");
-
-    println!("Graph generated as 'call_graph.svg'.");
+                let mut visitor = e2::visitors::RustVisitor::new();
+                visitor.visit_file(&syntax_tree);
+            }
+        }
+    }
 }

--- a/src/visitors/mod.rs
+++ b/src/visitors/mod.rs
@@ -1,0 +1,3 @@
+pub use rust::RustVisitor;
+
+mod rust;

--- a/src/visitors/rust.rs
+++ b/src/visitors/rust.rs
@@ -1,0 +1,39 @@
+use syn::{visit::Visit, ItemFn};
+
+use crate::ast::{Function, Ident};
+
+pub struct RustVisitor {
+    functions: Vec<Function>,
+}
+
+impl RustVisitor {
+    pub fn new() -> Self {
+        Self {
+            functions: Vec::new(),
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for RustVisitor {
+    fn visit_item_fn(&mut self, node: &'ast ItemFn) {
+        let mut called_functions = Vec::new();
+
+        for stmt in &node.block.stmts {
+            if let syn::Stmt::Expr(expr, _) = stmt {
+                if let syn::Expr::Call(call_expr) = expr {
+                    if let syn::Expr::Path(path) = *call_expr.func.clone() {
+                        if let Some(segment) = path.path.segments.first() {
+                            called_functions.push(segment.ident.to_string());
+                        }
+                    }
+                }
+            }
+        }
+
+        self.functions.push(Function {
+            name: Ident::from(&node.sig.ident)
+        });
+
+        syn::visit::visit_item_fn(self, node);
+    }
+}


### PR DESCRIPTION
This pull request starts a rewrite of the actual code by separated the executable part (in the main.rs) and the logic part (in lib.rs).

For that I start by create 3 modules:
- `ast`: for the generalized ast (to avoid depending on syn for potential other language)
- `cli`: for the cli
- `visitors`: for the main part of the project (see the link to understand more the [concept](https://en.wikipedia.org/wiki/Visitor_pattern))
  - `visitors/rust.rs`: for a visitor relative to the rust language